### PR TITLE
[PHP 8.4] Fix: Implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/NanoId.php
+++ b/src/NanoId.php
@@ -18,7 +18,7 @@ class NanoId implements NanoIdInterface
     /**
      * @inheritDoc
      */
-    public static function nanoId(int $size = NanoIdInterface::SIZE_DEFAULT, string $alphabet = null): string
+    public static function nanoId(int $size = NanoIdInterface::SIZE_DEFAULT, ?string $alphabet = null): string
     {
         return self::getFactory()->nanoId($size, $alphabet);
     }
@@ -26,7 +26,7 @@ class NanoId implements NanoIdInterface
     /**
      * @inheritDoc
      */
-    public static function nanoIdNonSecure(int $size = NanoIdInterface::SIZE_DEFAULT, string $alphabet = null): string
+    public static function nanoIdNonSecure(int $size = NanoIdInterface::SIZE_DEFAULT, ?string $alphabet = null): string
     {
         return self::getFactory()->nanoIdNonSecure($size, $alphabet);
     }

--- a/src/NanoIdFactory.php
+++ b/src/NanoIdFactory.php
@@ -10,7 +10,7 @@ class NanoIdFactory implements NanoIdFactoryInterface
 {
     protected NanoIdGenerator $nanoIdGenerator;
 
-    public function __construct(RandomBytesGeneratorInterface $randomBytesGenerator = null)
+    public function __construct(?RandomBytesGeneratorInterface $randomBytesGenerator = null)
     {
         $this->nanoIdGenerator = new NanoIdGenerator($randomBytesGenerator ?? new RandomBytesGenerator());
     }
@@ -18,7 +18,7 @@ class NanoIdFactory implements NanoIdFactoryInterface
     /**
      * @inheritDoc
      */
-    public function nanoId(int $size, string $alphabet = null): string
+    public function nanoId(int $size, ?string $alphabet = null): string
     {
         return null === $alphabet
             ? $this->nanoIdGenerator->nanoId($size)
@@ -28,7 +28,7 @@ class NanoIdFactory implements NanoIdFactoryInterface
     /**
      * @inheritDoc
      */
-    public function nanoIdNonSecure(int $size, string $alphabet = null): string
+    public function nanoIdNonSecure(int $size, ?string $alphabet = null): string
     {
         return null === $alphabet
             ? $this->nanoIdGenerator->nanoIdNonSecure($size)

--- a/src/NanoIdFactoryInterface.php
+++ b/src/NanoIdFactoryInterface.php
@@ -7,10 +7,10 @@ interface NanoIdFactoryInterface
     /**
      * @throws \InvalidArgumentException
      */
-    public function nanoId(int $size, string $alphabet = null): string;
+    public function nanoId(int $size, ?string $alphabet = null): string;
 
     /**
      * @throws \InvalidArgumentException
      */
-    public function nanoIdNonSecure(int $size, string $alphabet = null): string;
+    public function nanoIdNonSecure(int $size, ?string $alphabet = null): string;
 }

--- a/src/NanoIdInterface.php
+++ b/src/NanoIdInterface.php
@@ -40,7 +40,7 @@ interface NanoIdInterface
      *
      * @throws \InvalidArgumentException
      */
-    public static function nanoId(int $size = NanoIdGenerator::SIZE, string $alphabet = null): string;
+    public static function nanoId(int $size = NanoIdGenerator::SIZE, ?string $alphabet = null): string;
 
     /**
      * Generates a tiny, secure, URL-friendly, unique string with custom size and optionally with custom alphabet using the faster non-secure generator.
@@ -50,5 +50,5 @@ interface NanoIdInterface
      *
      * @throws \InvalidArgumentException
      */
-    public static function nanoIdNonSecure(int $size = NanoIdGenerator::SIZE, string $alphabet = null): string;
+    public static function nanoIdNonSecure(int $size = NanoIdGenerator::SIZE, ?string $alphabet = null): string;
 }


### PR DESCRIPTION
fixes #2 